### PR TITLE
Add deploy command using Now.sh and setup docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Use Node.js version 10
+FROM mhart/alpine-node:10
+
+# Set the working directory
+WORKDIR /usr/src
+
+# Copy package manager files to the working directory and run install
+COPY package.json yarn.lock ./
+RUN yarn install
+
+# Copy all files to the working directory
+COPY . .
+
+# Run tests
+# RUN CI=true yarn test
+
+# Build the app and move the resulting build to the `/public` directory
+RUN yarn catalog-build
+RUN mv ./catalog/build /public

--- a/now.json
+++ b/now.json
@@ -1,0 +1,11 @@
+{
+  "type": "static",
+  "static": {
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "test": "yarn build",
     "build": "npm-run-all --sequential css-main catalog-build",
+    "deploy": "now --public",
     "catalog-start": "catalog start",
     "catalog-build": "catalog build",
     "css-main": "npm-run-all --sequential css-compile css-prefix css-minify css-copy",


### PR DESCRIPTION
This will currently deploy a public app using https://zeit.co/ 

Can be easily changed to any other docker based deployment service.

Example: https://vattenfall-one-brand-design-system-cdcppbqsde.now.sh/